### PR TITLE
correct jquery selector to properly select basics tab in scene config in v13

### DIFF
--- a/monks-wall-enhancement.js
+++ b/monks-wall-enhancement.js
@@ -1429,7 +1429,7 @@ Hooks.on("renderSceneControls", (controls, html) => {
 });
 
 Hooks.on('renderSceneConfig', async (app, html, options) => {
-    let tab = $('.tab[data-tab="basic"]', html);
+    let tab = $('.tab[data-tab="basics"]', html);
     tab.append($('<hr>'))
         .append($('<div>')
             .addClass("form-group")


### PR DESCRIPTION
The wall scene and close doors buttons are not properly displaying in the scene config. This fixes that issue.